### PR TITLE
Fix typo in F4PGA organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A curated list of awesome open source hardware tools.
   * An infrastructure for integrated EDA
 * [edalize](https://github.com/olofk/edalize)
   * An abstraction library for interfacing EDA tools.
-* [f4fpga](https://github.com/SymbiFlow/f4pga-arch-defs)
+* [f4pga](https://github.com/SymbiFlow/f4pga-arch-defs)
   * Architecture definitions of FPGA hardware
 * [fusesoc](https://github.com/olofk/fusesoc)
   * Package manager and build abstraction tool for FPGA/ASIC development.


### PR DESCRIPTION
The correct name of the organization is F4PGA. This PR fixes the typo.